### PR TITLE
Support bash variable and k8s pod volume

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,16 +4,48 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/project"
+	"io/ioutil"
+	"os"
+	"runtime/debug"
 )
 
-func ParseDockerCompose(filename string) (*project.Project, error) {
-	context := &docker.Context{}
-	if filename == "" {
-		filename = "docker-compose.yml"
+func ParseDockerCompose(filePath string) (composeObject *project.Project, err error) {
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, err
 	}
-	context.ComposeFiles = []string{filename}
-	composeObject := project.NewProject(&context.Context, nil, nil)
-	err := composeObject.Parse()
+	sanitizedCompose := []byte(os.ExpandEnv(string(content)))
+	tmpfile, err := ioutil.TempFile("/tmp", "sanitized-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmpfile.Name())
+
+	if _, err := tmpfile.Write(sanitizedCompose); err != nil {
+		log.Fatal(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	return libcomposeParser(tmpfile.Name())
+}
+
+func libcomposeParser(filePath string) (composeObject *project.Project, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Infof("Recovered in pkg/utils/utils.go libcomposeParser(filePath string) %#v\n", r)
+			debug.PrintStack()
+			err = r.(error)
+		}
+	}()
+	context := &docker.Context{}
+	if filePath == "" {
+		filePath = "docker-compose.yml"
+	}
+	context.ComposeFiles = []string{filePath}
+	composeObject = project.NewProject(&context.Context, nil, nil)
+	err = composeObject.Parse()
 	if err != nil {
 		log.Fatalf("Failed to load compose file", err)
 		return nil, err


### PR DESCRIPTION
1. When docker-compose.yml contains `${variable}`, libcompose parser would fail with `"invalid memory address or nil pointer dereference"`
   With this change, user can provide those bash variables as `os.Environ()`
2. Default storage will be using k8s' `EmptyDir` volume type 
